### PR TITLE
Implement dashboard scaffold and docker docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ npm-debug.log*
 .env.local
 
 backend/uploads/
+backend/node_modules/
+backend/pnpm-lock.yaml
+frontend/pnpm-lock.yaml

--- a/.project-management/current-prd/tasks-feature-specification.md
+++ b/.project-management/current-prd/tasks-feature-specification.md
@@ -127,7 +127,7 @@
   - [ ] 3.3 Implement proactive suggestion logic leveraging interaction history
   - [ ] 3.4 Add tests for AI services and stub external API calls
 - [ ] **4.0 Frontend Implementation**
-  - [ ] 4.1 Scaffold dashboard page and task list component with DaisyUI styling
+  - [x] 4.1 Scaffold dashboard page and task list component with DaisyUI styling
   - [ ] 4.2 Connect frontend to backend APIs using React Query hooks
   - [ ] 4.3 Manage client state with Zustand stores
   - [ ] 4.4 Display Today’s Plan with task metadata and status indicators
@@ -136,7 +136,7 @@
   - [ ] 5.1 Implement real-time sync using y-websocket and Yjs
   - [ ] 5.2 Set up WebSocket notifications for task reminders
   - [x] 5.3 Create Dockerfiles and docker-compose configuration for full stack
-  - [ ] 5.4 Document Docker workflow in README and `dev_init.sh`
+  - [x] 5.4 Document Docker workflow in README and `dev_init.sh`
 - [ ] **6.0 Testing & Quality Assurance**
   - [ ] 6.1 Configure Jest and ESLint pre-commit hooks
   - [ ] 6.2 Achieve >80% unit test coverage across frontend and backend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 2025-07-25T01:46:25Z Fix Prisma client generation in test script
 2025-07-25T16:51:24Z Add docker-compose setup and environment template
 2025-07-25T20:36:37Z Update CI to Node.js 20
+2025-07-25T22:37:38Z Document Docker workflow and scaffold dashboard

--- a/README.md
+++ b/README.md
@@ -139,4 +139,15 @@ npx prisma db push
 npx prisma db seed  # Optional: seed with sample data
 ```
 
+
+### Docker Workflow
+For a containerized setup, ensure Docker is installed and running. Start all services using docker-compose with:
+```bash
+USE_DOCKER=true ./dev_init.sh
+```
+This command builds the images and launches the database, backend, and frontend containers defined in `docker-compose.yml`.
+To stop the containers when finished, run:
+```bash
+docker compose down
+```
 *End of document*

--- a/dev_init.sh
+++ b/dev_init.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Run with USE_DOCKER=true to start docker-compose containers
+
 set -euo pipefail
 
 echo "🚀 Starting Codex Bootstrap Development Environment (Node.js Full-Stack)"
@@ -8,6 +10,7 @@ echo "🚀 Starting Codex Bootstrap Development Environment (Node.js Full-Stack)
 if [ "$USE_DOCKER" = "true" ] && command -v docker >/dev/null 2>&1; then
     echo "🐳 Starting services using docker-compose..."
     docker compose up -d
+    echo "🛑 Stop containers with: docker compose down"
     echo "✅ Containers started. Frontend: http://localhost:3000  Backend: http://localhost:8000"
     exit 0
 fi

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,0 +1,16 @@
+import TaskList, { Task } from '@/components/TaskList'
+
+const sampleTasks: Task[] = [
+  { id: 1, title: 'Set up project', completed: true },
+  { id: 2, title: 'Connect backend API', completed: false },
+  { id: 3, title: 'Write documentation', completed: false },
+]
+
+export default function DashboardPage() {
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Dashboard</h1>
+      <TaskList tasks={sampleTasks} />
+    </main>
+  )
+}

--- a/frontend/src/components/TaskList.test.tsx
+++ b/frontend/src/components/TaskList.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react'
+import TaskList, { Task } from './TaskList'
+
+const tasks: Task[] = [
+  { id: 1, title: 'First task', completed: false },
+  { id: 2, title: 'Second task', completed: true },
+]
+
+describe('TaskList', () => {
+  it('renders provided tasks', () => {
+    render(<TaskList tasks={tasks} />)
+    expect(screen.getByText('First task')).toBeInTheDocument()
+    expect(screen.getByText('Second task')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/TaskList.tsx
+++ b/frontend/src/components/TaskList.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+
+export interface Task {
+  id: number
+  title: string
+  completed: boolean
+}
+
+interface TaskListProps {
+  tasks: Task[]
+}
+
+export default function TaskList({ tasks }: TaskListProps) {
+  return (
+    <ul className="space-y-2">
+      {tasks.map((task) => (
+        <li key={task.id} className="flex items-center gap-2 p-2 rounded bg-base-200">
+          <input
+            type="checkbox"
+            className="checkbox checkbox-primary"
+            checked={task.completed}
+            readOnly
+          />
+          <span className={task.completed ? 'line-through' : ''}>{task.title}</span>
+        </li>
+      ))}
+    </ul>
+  )
+}


### PR DESCRIPTION
## Summary
- scaffold dashboard route and TaskList component
- add Docker workflow docs to README and dev_init.sh
- ignore node_modules and pnpm locks
- update tasks list for completed items

## Testing
- `npm --prefix frontend run lint`
- `flake8`
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_b_68840633b6588320b888d9f52db1ca53