### PR TITLE
Implement React Query tasks API

### DIFF
--- a/.project-management/current-prd/tasks-feature-specification.md
+++ b/.project-management/current-prd/tasks-feature-specification.md
@@ -103,6 +103,10 @@
 - `frontend/package.json` - Add Zustand and React Query
 - `frontend/src/app/dashboard/page.tsx` - Integrate tasks store
 - `frontend/src/components/TaskList.tsx` - Toggle tasks via store
+- `frontend/src/hooks/useApi.ts` - React Query hooks for API access
+- `frontend/src/store/tasksStore.ts` - Update store with setTasks helper
+- `frontend/src/store/tasksStore.test.ts` - Unit tests for tasks store
+- `backend/src/app.module.ts` - Register TasksModule
 - `README.md` - Update setup instructions
 - `.gitignore` - Ignore local environment files
 - `.project-management/current-prd/tasks-feature-specification.md` - Task list
@@ -131,7 +135,7 @@
   - [ ] 3.4 Add tests for AI services and stub external API calls
 - [ ] **4.0 Frontend Implementation**
   - [x] 4.1 Scaffold dashboard page and task list component with DaisyUI styling
-  - [ ] 4.2 Connect frontend to backend APIs using React Query hooks
+  - [c] 4.2 Connect frontend to backend APIs using React Query hooks
   - [x] 4.3 Manage client state with Zustand stores
   - [ ] 4.4 Display Today’s Plan with task metadata and status indicators
   - [ ] 4.5 Write unit tests for components and stores

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@
 2025-07-25T22:37:38Z Document Docker workflow and scaffold dashboard
 2025-07-25T23:07:46Z Add Zustand tasks store and integrate dashboard
 2025-07-26T00:33:44Z Add Husky pre-commit hooks
+2025-07-26T01:20:25Z Integrate backend tasks API with React Query

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,6 +6,7 @@ import { UsersModule } from './users/users.module';
 import { CollaborationModule } from './collaboration/collaboration.module';
 import { GraphModule } from './integrations/graph/graph.module';
 import { GoogleModule } from './integrations/google/google.module';
+import { TasksModule } from './tasks/tasks.module';
 
 @Module({
   imports: [
@@ -14,6 +15,7 @@ import { GoogleModule } from './integrations/google/google.module';
     CollaborationModule,
     GraphModule,
     GoogleModule,
+    TasksModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/tasks/tasks.controller.ts
+++ b/backend/src/tasks/tasks.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get, Param, Patch } from '@nestjs/common'
+import { TasksService, Task } from './tasks.service'
+
+@Controller('tasks')
+export class TasksController {
+  constructor(private readonly tasksService: TasksService) {}
+
+  @Get()
+  getTasks(): Task[] {
+    return this.tasksService.findAll()
+  }
+
+  @Patch(':id/toggle')
+  toggleTask(@Param('id') id: string): Task | undefined {
+    return this.tasksService.toggle(Number(id))
+  }
+}

--- a/backend/src/tasks/tasks.module.ts
+++ b/backend/src/tasks/tasks.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common'
+import { TasksController } from './tasks.controller'
+import { TasksService } from './tasks.service'
+
+@Module({
+  controllers: [TasksController],
+  providers: [TasksService],
+  exports: [TasksService],
+})
+export class TasksModule {}

--- a/backend/src/tasks/tasks.service.spec.ts
+++ b/backend/src/tasks/tasks.service.spec.ts
@@ -1,0 +1,23 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { TasksService } from './tasks.service'
+
+describe('TasksService', () => {
+  let service: TasksService
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [TasksService],
+    }).compile()
+
+    service = module.get<TasksService>(TasksService)
+  })
+
+  it('should be defined', () => {
+    expect(service).toBeDefined()
+  })
+
+  it('toggles task completion', () => {
+    const task = service.toggle(1)
+    expect(task?.completed).toBe(true)
+  })
+})

--- a/backend/src/tasks/tasks.service.ts
+++ b/backend/src/tasks/tasks.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common'
+
+export interface Task {
+  id: number
+  title: string
+  completed: boolean
+}
+
+@Injectable()
+export class TasksService {
+  private tasks: Task[] = [
+    { id: 1, title: 'Set up project', completed: false },
+    { id: 2, title: 'Connect backend API', completed: false },
+    { id: 3, title: 'Write documentation', completed: false },
+  ]
+  private nextId = 4
+
+  findAll(): Task[] {
+    return this.tasks
+  }
+
+  toggle(id: number): Task | undefined {
+    const task = this.tasks.find((t) => t.id === id)
+    if (task) {
+      task.completed = !task.completed
+    }
+    return task
+  }
+}

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,26 +1,26 @@
 import { useEffect } from 'react'
 import TaskList from '@/components/TaskList'
 import { useTasksStore } from '@/store/tasksStore'
-
-const initialTasks = [
-  'Set up project',
-  'Connect backend API',
-  'Write documentation',
-]
+import { useTasks, useToggleTask } from '@/hooks/useApi'
 
 export default function DashboardPage() {
-  const { tasks, addTask, toggleTask } = useTasksStore()
+  const { tasks, setTasks } = useTasksStore()
+  const { data } = useTasks()
+  const toggleMutation = useToggleTask()
 
   useEffect(() => {
-    if (tasks.length === 0) {
-      initialTasks.forEach((t) => addTask(t))
+    if (data) {
+      setTasks(data)
     }
-  }, [tasks.length, addTask])
+  }, [data, setTasks])
 
   return (
     <main className="p-4 space-y-4">
       <h1 className="text-2xl font-bold">Dashboard</h1>
-      <TaskList tasks={tasks} onToggle={toggleTask} />
+      <TaskList
+        tasks={tasks}
+        onToggle={(id) => toggleMutation.mutate(id)}
+      />
     </main>
   )
 }

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -13,11 +13,19 @@ interface CreateUserInput {
   email: string
 }
 
+export interface ApiTask {
+  id: number
+  title: string
+  completed: boolean
+}
+
 // Query keys
 export const queryKeys = {
   users: ['users'] as const,
   user: (id: string) => ['users', id] as const,
   health: ['health'] as const,
+  tasks: ['tasks'] as const,
+  task: (id: number) => ['tasks', id] as const,
 }
 
 // Health check hook
@@ -77,6 +85,25 @@ export function useDeleteUser() {
     mutationFn: (id: string) => api.delete(`/users/${id}`),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.users })
+    },
+  })
+}
+
+// Tasks hooks
+export function useTasks() {
+  return useQuery({
+    queryKey: queryKeys.tasks,
+    queryFn: () => api.get<ApiTask[]>('/tasks'),
+  })
+}
+
+export function useToggleTask() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (id: number) => api.patch<ApiTask>(`/tasks/${id}/toggle`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.tasks })
     },
   })
 }

--- a/frontend/src/store/tasksStore.test.ts
+++ b/frontend/src/store/tasksStore.test.ts
@@ -48,4 +48,18 @@ describe('useTasksStore', () => {
 
     expect(result.current.tasks).toHaveLength(0)
   })
+
+  it('sets tasks', () => {
+    const { result } = renderHook(() => useTasksStore())
+
+    act(() => {
+      result.current.setTasks([
+        { id: 1, title: 'A', completed: false },
+        { id: 2, title: 'B', completed: true },
+      ])
+    })
+
+    expect(result.current.tasks).toHaveLength(2)
+    expect(result.current.tasks[1].completed).toBe(true)
+  })
 })

--- a/frontend/src/store/tasksStore.ts
+++ b/frontend/src/store/tasksStore.ts
@@ -11,6 +11,7 @@ interface TasksState {
   addTask: (title: string) => void
   toggleTask: (id: number) => void
   removeTask: (id: number) => void
+  setTasks: (tasks: Task[]) => void
 }
 
 let nextId = 1
@@ -34,4 +35,5 @@ export const useTasksStore = create<TasksState>((set) => ({
     set((state) => ({
       tasks: state.tasks.filter((t) => t.id !== id),
     })),
+  setTasks: (tasks) => set({ tasks }),
 }))


### PR DESCRIPTION
## Summary
- wire up a basic tasks API in NestJS
- expose tasks hooks on the frontend
- sync dashboard tasks with backend
- extend tasks store to allow bulk set
- document work in project task list

## Testing
- `npm run lint`
- `flake8`
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_b_68842c07c9d48320899ea5e6d813bfa1