### PR TITLE
Implement today's plan feature

### DIFF
--- a/.project-management/current-prd/tasks-feature-specification.md
+++ b/.project-management/current-prd/tasks-feature-specification.md
@@ -101,11 +101,14 @@
 - `backend/prisma/schema.prisma` - Add new tables according to PRD
 - `backend/package.json` - Add dependencies like @nestjs/jwt, @prisma/client
 - `frontend/package.json` - Add Zustand and React Query
-- `frontend/src/app/dashboard/page.tsx` - Integrate tasks store
-- `frontend/src/components/TaskList.tsx` - Toggle tasks via store
-- `frontend/src/hooks/useApi.ts` - React Query hooks for API access
-- `frontend/src/store/tasksStore.ts` - Update store with setTasks helper
-- `frontend/src/store/tasksStore.test.ts` - Unit tests for tasks store
+ - `frontend/src/app/dashboard/page.tsx` - Display today's plan and all tasks
+ - `frontend/src/components/TaskList.tsx` - Show due dates and status badges
+ - `frontend/src/hooks/useApi.ts` - Add ApiTask dueDate property
+ - `frontend/src/store/tasksStore.ts` - Handle tasks with due dates
+ - `frontend/src/store/tasksStore.test.ts` - Unit tests for tasks store
+ - `frontend/src/components/TaskList.test.tsx` - Tests for TaskList component
+ - `backend/src/tasks/tasks.service.ts` - Provide tasks with due dates
+ - `backend/src/tasks/tasks.service.spec.ts` - Updated tests for due dates
 - `backend/src/app.module.ts` - Register TasksModule
 - `README.md` - Update setup instructions
 - `.gitignore` - Ignore local environment files
@@ -135,9 +138,9 @@
   - [ ] 3.4 Add tests for AI services and stub external API calls
 - [ ] **4.0 Frontend Implementation**
   - [x] 4.1 Scaffold dashboard page and task list component with DaisyUI styling
-  - [c] 4.2 Connect frontend to backend APIs using React Query hooks
+  - [x] 4.2 Connect frontend to backend APIs using React Query hooks
   - [x] 4.3 Manage client state with Zustand stores
-  - [ ] 4.4 Display Today’s Plan with task metadata and status indicators
+  - [x] 4.4 Display Today’s Plan with task metadata and status indicators
   - [ ] 4.5 Write unit tests for components and stores
 - [ ] **5.0 Sync, Notifications & Docker**
   - [x] 5.1 Implement real-time sync using y-websocket and Yjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@
 2025-07-25T23:07:46Z Add Zustand tasks store and integrate dashboard
 2025-07-26T00:33:44Z Add Husky pre-commit hooks
 2025-07-26T01:20:25Z Integrate backend tasks API with React Query
+2025-07-26T01:57:27Z Add due dates and today's plan display

--- a/backend/src/tasks/tasks.service.spec.ts
+++ b/backend/src/tasks/tasks.service.spec.ts
@@ -20,4 +20,9 @@ describe('TasksService', () => {
     const task = service.toggle(1)
     expect(task?.completed).toBe(true)
   })
+
+  it('returns tasks with due dates', () => {
+    const tasks = service.findAll()
+    expect(tasks[0].dueDate).toMatch(/\d{4}-\d{2}-\d{2}/)
+  })
 })

--- a/backend/src/tasks/tasks.service.ts
+++ b/backend/src/tasks/tasks.service.ts
@@ -4,14 +4,30 @@ export interface Task {
   id: number
   title: string
   completed: boolean
+  dueDate: string
 }
 
 @Injectable()
 export class TasksService {
   private tasks: Task[] = [
-    { id: 1, title: 'Set up project', completed: false },
-    { id: 2, title: 'Connect backend API', completed: false },
-    { id: 3, title: 'Write documentation', completed: false },
+    {
+      id: 1,
+      title: 'Set up project',
+      completed: false,
+      dueDate: new Date().toISOString().slice(0, 10),
+    },
+    {
+      id: 2,
+      title: 'Connect backend API',
+      completed: false,
+      dueDate: new Date().toISOString().slice(0, 10),
+    },
+    {
+      id: 3,
+      title: 'Write documentation',
+      completed: false,
+      dueDate: new Date().toISOString().slice(0, 10),
+    },
   ]
   private nextId = 4
 

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -8,6 +8,10 @@ export default function DashboardPage() {
   const { data } = useTasks()
   const toggleMutation = useToggleTask()
 
+  const today = new Date().toISOString().slice(0, 10)
+
+  const todaysTasks = tasks.filter((t) => t.dueDate === today)
+
   useEffect(() => {
     if (data) {
       setTasks(data)
@@ -17,10 +21,21 @@ export default function DashboardPage() {
   return (
     <main className="p-4 space-y-4">
       <h1 className="text-2xl font-bold">Dashboard</h1>
-      <TaskList
-        tasks={tasks}
-        onToggle={(id) => toggleMutation.mutate(id)}
-      />
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Today&apos;s Plan</h2>
+        <TaskList
+          tasks={todaysTasks}
+          onToggle={(id) => toggleMutation.mutate(id)}
+        />
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-2">All Tasks</h2>
+        <TaskList
+          tasks={tasks}
+          onToggle={(id) => toggleMutation.mutate(id)}
+        />
+      </section>
     </main>
   )
 }

--- a/frontend/src/components/TaskList.test.tsx
+++ b/frontend/src/components/TaskList.test.tsx
@@ -2,8 +2,8 @@ import { render, screen } from '@testing-library/react'
 import TaskList, { Task } from './TaskList'
 
 const tasks: Task[] = [
-  { id: 1, title: 'First task', completed: false },
-  { id: 2, title: 'Second task', completed: true },
+  { id: 1, title: 'First task', completed: false, dueDate: '2024-01-01' },
+  { id: 2, title: 'Second task', completed: true, dueDate: '2024-01-02' },
 ]
 
 describe('TaskList', () => {
@@ -11,5 +11,6 @@ describe('TaskList', () => {
     render(<TaskList tasks={tasks} />)
     expect(screen.getByText('First task')).toBeInTheDocument()
     expect(screen.getByText('Second task')).toBeInTheDocument()
+    expect(screen.getByText('2024-01-01')).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/TaskList.tsx
+++ b/frontend/src/components/TaskList.tsx
@@ -4,6 +4,7 @@ export interface Task {
   id: number
   title: string
   completed: boolean
+  dueDate: string
 }
 
 interface TaskListProps {
@@ -23,6 +24,10 @@ export default function TaskList({ tasks, onToggle }: TaskListProps) {
             onChange={() => onToggle?.(task.id)}
           />
           <span className={task.completed ? 'line-through' : ''}>{task.title}</span>
+          <span className="badge badge-ghost badge-sm ml-auto">
+            {task.completed ? 'Done' : 'Pending'}
+          </span>
+          <span className="text-xs text-gray-500">{task.dueDate}</span>
         </li>
       ))}
     </ul>

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -17,6 +17,7 @@ export interface ApiTask {
   id: number
   title: string
   completed: boolean
+  dueDate: string
 }
 
 // Query keys

--- a/frontend/src/store/tasksStore.test.ts
+++ b/frontend/src/store/tasksStore.test.ts
@@ -15,6 +15,7 @@ describe('useTasksStore', () => {
 
     expect(result.current.tasks).toHaveLength(1)
     expect(result.current.tasks[0].title).toBe('First')
+    expect(result.current.tasks[0].dueDate).toMatch(/\d{4}-\d{2}-\d{2}/)
   })
 
   it('toggles tasks', () => {
@@ -54,12 +55,23 @@ describe('useTasksStore', () => {
 
     act(() => {
       result.current.setTasks([
-        { id: 1, title: 'A', completed: false },
-        { id: 2, title: 'B', completed: true },
+        {
+          id: 1,
+          title: 'A',
+          completed: false,
+          dueDate: '2024-01-01',
+        },
+        {
+          id: 2,
+          title: 'B',
+          completed: true,
+          dueDate: '2024-01-02',
+        },
       ])
     })
 
     expect(result.current.tasks).toHaveLength(2)
     expect(result.current.tasks[1].completed).toBe(true)
+    expect(result.current.tasks[0].dueDate).toBe('2024-01-01')
   })
 })

--- a/frontend/src/store/tasksStore.ts
+++ b/frontend/src/store/tasksStore.ts
@@ -4,6 +4,7 @@ export interface Task {
   id: number
   title: string
   completed: boolean
+  dueDate: string
 }
 
 interface TasksState {
@@ -22,7 +23,12 @@ export const useTasksStore = create<TasksState>((set) => ({
     set((state) => ({
       tasks: [
         ...state.tasks,
-        { id: nextId++, title, completed: false },
+        {
+          id: nextId++,
+          title,
+          completed: false,
+          dueDate: new Date().toISOString().slice(0, 10),
+        },
       ],
     })),
   toggleTask: (id) =>


### PR DESCRIPTION
## Summary
- display today's plan on dashboard with tasks due today
- show due date & status badge in TaskList
- support due dates in the tasks API, store and hooks
- update unit tests for store and components
- mark completed tasks in the task list

## Testing
- `npm run lint`
- `flake8`
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_b_6884350e9fbc83209f349a977b0440bd