### PR TITLE
Add Projects module

### DIFF
--- a/.project-management/current-prd/tasks-feature-specification.md
+++ b/.project-management/current-prd/tasks-feature-specification.md
@@ -76,6 +76,8 @@
 - `backend/src/projects/projects.module.ts` - NestJS module to manage projects
 - `backend/src/projects/projects.controller.ts` - CRUD endpoints for projects
 - `backend/src/projects/projects.service.ts` - Business logic for projects
+- `backend/src/projects/dto/project.dto.ts` - DTOs for project creation and update
+- `backend/src/projects/projects.service.spec.ts` - Tests for project service
 - `backend/src/tasks/tasks.module.ts` - Module for task management
 - `backend/src/tasks/tasks.controller.ts` - CRUD endpoints for tasks
 - `backend/src/tasks/tasks.service.ts` - Logic for tasks and metadata
@@ -111,7 +113,7 @@
 - `backend/src/tasks/tasks.service.ts` - Provide tasks with due dates
 - `backend/src/tasks/tasks.service.spec.ts` - Updated tests for due dates
 - `backend/src/tasks/tasks.module.ts` - Inject notifications gateway
-- `backend/src/app.module.ts` - Register TasksModule
+- `backend/src/app.module.ts` - Register TasksModule and ProjectsModule
 - `backend/src/prisma/prisma.service.ts` - Run migrations at startup
 - `README.md` - Update setup instructions
 - `.gitignore` - Ignore local environment files
@@ -131,7 +133,7 @@
 - [ ] **2.0 Database & Backend API**
   - [x] 2.1 Extend `schema.prisma` to include Users, Projects, Tasks, TaskDependencies, Notifications, InteractionLogs, UserSettings, Tags, and related tables
   - [x] 2.2 Generate Prisma migrations and update `prisma.service.ts`
-  - [ ] 2.3 Implement NestJS modules, controllers, and services for Users, Projects, Tasks, and Notifications
+  - [x] 2.3 Implement NestJS modules, controllers, and services for Users, Projects, Tasks, and Notifications
   - [ ] 2.4 Add JWT authentication and OAuth2 (Google/Microsoft) using `auth` module
   - [ ] 2.5 Write unit tests for each service and controller
 - [ ] **3.0 AI Integration**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@
 2025-07-26T02:16:40Z Add project and task models to Prisma schema
 2025-07-26T02:34:32Z Mark frontend unit tests completed
 2025-07-26T02:45:34Z Add Prisma migrations and notifications gateway
+2025-07-26T02:54:16Z Add NestJS Projects module with CRUD endpoints

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -8,6 +8,7 @@ import { GraphModule } from './integrations/graph/graph.module';
 import { GoogleModule } from './integrations/google/google.module';
 import { TasksModule } from './tasks/tasks.module';
 import { NotificationsModule } from './notifications/notifications.module';
+import { ProjectsModule } from './projects/projects.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { NotificationsModule } from './notifications/notifications.module';
     CollaborationModule,
     GraphModule,
     GoogleModule,
+    ProjectsModule,
     TasksModule,
     NotificationsModule,
   ],

--- a/backend/src/projects/dto/project.dto.ts
+++ b/backend/src/projects/dto/project.dto.ts
@@ -1,0 +1,19 @@
+import { IsOptional, IsString } from 'class-validator';
+import { ApiProperty, PartialType } from '@nestjs/swagger';
+
+export class CreateProjectDto {
+  @ApiProperty({ description: 'Project name' })
+  @IsString()
+  name: string;
+
+  @ApiProperty({ description: 'Project description', required: false })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiProperty({ description: 'Owner user ID' })
+  @IsString()
+  ownerId: string;
+}
+
+export class UpdateProjectDto extends PartialType(CreateProjectDto) {}

--- a/backend/src/projects/projects.controller.ts
+++ b/backend/src/projects/projects.controller.ts
@@ -1,0 +1,42 @@
+import { Controller, Get, Post, Patch, Delete, Param, Body, HttpCode, HttpStatus } from '@nestjs/common'
+import { ProjectsService } from './projects.service'
+import { CreateProjectDto, UpdateProjectDto } from './dto/project.dto'
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger'
+
+@ApiTags('projects')
+@Controller('projects')
+export class ProjectsController {
+  constructor(private readonly projectsService: ProjectsService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Create a new project' })
+  @ApiResponse({ status: 201, description: 'Project created successfully' })
+  create(@Body() dto: CreateProjectDto) {
+    return this.projectsService.create(dto)
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'Get all projects' })
+  findAll() {
+    return this.projectsService.findAll()
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get project by ID' })
+  findOne(@Param('id') id: string) {
+    return this.projectsService.findOne(id)
+  }
+
+  @Patch(':id')
+  @ApiOperation({ summary: 'Update project' })
+  update(@Param('id') id: string, @Body() dto: UpdateProjectDto) {
+    return this.projectsService.update(id, dto)
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete project' })
+  remove(@Param('id') id: string) {
+    return this.projectsService.remove(id)
+  }
+}

--- a/backend/src/projects/projects.module.ts
+++ b/backend/src/projects/projects.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common'
+import { ProjectsService } from './projects.service'
+import { ProjectsController } from './projects.controller'
+
+@Module({
+  controllers: [ProjectsController],
+  providers: [ProjectsService],
+  exports: [ProjectsService],
+})
+export class ProjectsModule {}

--- a/backend/src/projects/projects.service.spec.ts
+++ b/backend/src/projects/projects.service.spec.ts
@@ -1,0 +1,39 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { ProjectsService } from './projects.service'
+import { PrismaService } from '../prisma/prisma.service'
+
+describe('ProjectsService', () => {
+  let service: ProjectsService
+  const mockPrisma = {
+    project: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ProjectsService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile()
+
+    service = module.get<ProjectsService>(ProjectsService)
+  })
+
+  it('should be defined', () => {
+    expect(service).toBeDefined()
+  })
+
+  it('should return all projects', async () => {
+    const projects = [{ id: '1', name: 'Proj' }]
+    mockPrisma.project.findMany.mockResolvedValue(projects)
+    const result = await service.findAll()
+    expect(result).toEqual(projects)
+    expect(mockPrisma.project.findMany).toHaveBeenCalled()
+  })
+})

--- a/backend/src/projects/projects.service.ts
+++ b/backend/src/projects/projects.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common'
+import { PrismaService } from '../prisma/prisma.service'
+import { CreateProjectDto, UpdateProjectDto } from './dto/project.dto'
+import { Project } from '@prisma/client'
+
+@Injectable()
+export class ProjectsService {
+  constructor(private prisma: PrismaService) {}
+
+  async create(data: CreateProjectDto): Promise<Project> {
+    return this.prisma.project.create({ data })
+  }
+
+  async findAll(): Promise<Project[]> {
+    return this.prisma.project.findMany({ orderBy: { createdAt: 'desc' } })
+  }
+
+  async findOne(id: string): Promise<Project | null> {
+    return this.prisma.project.findUnique({ where: { id } })
+  }
+
+  async update(id: string, data: UpdateProjectDto): Promise<Project> {
+    return this.prisma.project.update({ where: { id }, data })
+  }
+
+  async remove(id: string): Promise<Project> {
+    return this.prisma.project.delete({ where: { id } })
+  }
+}


### PR DESCRIPTION
## Summary
- implement ProjectsModule with controller, service, DTOs and tests
- register ProjectsModule in `AppModule`
- track progress in task list
- document new module in changelog

## Testing
- `npm run lint` in frontend
- `bash run_tests.sh`
- `flake8`

------
https://chatgpt.com/codex/tasks/task_b_6884426f7bec8320997e7f7aae813bc1