### PR TITLE
Implement AI module and controller tests

### DIFF
--- a/.project-management/current-prd/tasks-feature-specification.md
+++ b/.project-management/current-prd/tasks-feature-specification.md
@@ -90,6 +90,11 @@
 - `backend/prisma/migrations/001_init/migration.sql` - Initial schema migration
 - `backend/src/ai/ai.module.ts` - ChatGPT and Mem0 integration
 - `backend/src/ai/ai.service.ts` - AI interaction logic
+- `backend/src/ai/ai.service.spec.ts` - Tests for AI service
+- `backend/src/tasks/tasks.controller.spec.ts` - Tests for tasks controller
+- `backend/src/projects/projects.controller.spec.ts` - Tests for projects controller
+- `backend/src/users/users.controller.spec.ts` - Tests for users controller
+- `backend/src/auth/auth.controller.spec.ts` - Tests for auth controller
 - `frontend/src/app/dashboard/page.tsx` - Main dashboard view
 - `frontend/src/components/TaskList.tsx` - Task list component
 - `frontend/src/store/tasksStore.ts` - Zustand store for tasks
@@ -117,7 +122,7 @@
 - `backend/src/tasks/tasks.service.ts` - Provide tasks with due dates
 - `backend/src/tasks/tasks.service.spec.ts` - Updated tests for due dates
 - `backend/src/tasks/tasks.module.ts` - Inject notifications gateway
- - `backend/src/app.module.ts` - Register TasksModule, ProjectsModule, and AuthModule
+- `backend/src/app.module.ts` - Register TasksModule, ProjectsModule, AuthModule, and AiModule
 - `backend/src/prisma/prisma.service.ts` - Run migrations at startup
 - `README.md` - Update setup instructions
 - `.gitignore` - Ignore local environment files
@@ -134,17 +139,17 @@
   - [x] 1.1 Initialize frontend and backend repositories with GitHub Actions pipelines
   - [x] 1.2 Configure development and staging environments via `dev_init.sh` and docker-compose
   - [x] 1.3 Establish environment variable templates and secrets management
-- [ ] **2.0 Database & Backend API**
+- [x] **2.0 Database & Backend API**
   - [x] 2.1 Extend `schema.prisma` to include Users, Projects, Tasks, TaskDependencies, Notifications, InteractionLogs, UserSettings, Tags, and related tables
   - [x] 2.2 Generate Prisma migrations and update `prisma.service.ts`
   - [x] 2.3 Implement NestJS modules, controllers, and services for Users, Projects, Tasks, and Notifications
   - [x] 2.4 Add JWT authentication and OAuth2 (Google/Microsoft) using `auth` module
-  - [c] 2.5 Write unit tests for each service and controller
+  - [x] 2.5 Write unit tests for each service and controller
 - [ ] **3.0 AI Integration**
-  - [ ] 3.1 Create AI module to interface with ChatGPT API for task generation and summarization
+  - [x] 3.1 Create AI module to interface with ChatGPT API for task generation and summarization
   - [ ] 3.2 Integrate Mem0 for semantic memory storage and retrieval-augmented responses
   - [ ] 3.3 Implement proactive suggestion logic leveraging interaction history
-  - [ ] 3.4 Add tests for AI services and stub external API calls
+  - [x] 3.4 Add tests for AI services and stub external API calls
 - [x] **4.0 Frontend Implementation**
   - [x] 4.1 Scaffold dashboard page and task list component with DaisyUI styling
   - [x] 4.2 Connect frontend to backend APIs using React Query hooks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@
 2025-07-26T02:54:16Z Add NestJS Projects module with CRUD endpoints
 2025-07-26T03:10:12Z Implement basic JWT auth module
 2025-07-26T03:33:38Z Add Graph service and controller unit tests
+2025-07-26T04:38:21Z Add AI module and controller tests

--- a/backend/src/ai/ai.module.ts
+++ b/backend/src/ai/ai.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common'
+import { AiService } from './ai.service'
+
+@Module({
+  providers: [AiService],
+  exports: [AiService],
+})
+export class AiModule {}

--- a/backend/src/ai/ai.service.spec.ts
+++ b/backend/src/ai/ai.service.spec.ts
@@ -1,0 +1,30 @@
+import { AiService } from './ai.service'
+
+describe('AiService', () => {
+  let service: AiService
+  let mockFetch: jest.Mock
+
+  beforeEach(() => {
+    mockFetch = jest.fn().mockResolvedValue({
+      json: () => Promise.resolve({ choices: [{ message: { content: 'resp' } }] }),
+    })
+    global.fetch = mockFetch as any
+    service = new AiService()
+  })
+
+  it('generates tasks', async () => {
+    mockFetch.mockResolvedValueOnce({
+      json: () => Promise.resolve({ choices: [{ message: { content: 'a\nb' } }] }),
+    })
+    const result = await service.generateTasks('todo')
+    expect(result).toEqual(['a', 'b'])
+  })
+
+  it('summarizes text', async () => {
+    mockFetch.mockResolvedValueOnce({
+      json: () => Promise.resolve({ choices: [{ message: { content: 'sum' } }] }),
+    })
+    const result = await service.summarize('text')
+    expect(result).toBe('sum')
+  })
+})

--- a/backend/src/ai/ai.service.ts
+++ b/backend/src/ai/ai.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common'
+
+@Injectable()
+export class AiService {
+  constructor() {}
+
+  async generateTasks(prompt: string): Promise<string[]> {
+    const res = await this.request(prompt)
+    const content = res || ''
+    return content
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean)
+  }
+
+  async summarize(text: string): Promise<string> {
+    return this.request(`Summarize the following text:\n${text}`)
+  }
+
+  private async request(prompt: string): Promise<string> {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages: [{ role: 'user', content: prompt }],
+      }),
+    })
+    const data = await response.json()
+    return data.choices?.[0]?.message?.content ?? ''
+  }
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -10,6 +10,7 @@ import { TasksModule } from './tasks/tasks.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { ProjectsModule } from './projects/projects.module';
 import { AuthModule } from './auth/auth.module';
+import { AiModule } from './ai/ai.module';
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { AuthModule } from './auth/auth.module';
     TasksModule,
     NotificationsModule,
     AuthModule,
+    AiModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -1,0 +1,26 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { AuthController } from './auth.controller'
+import { AuthService } from './auth.service'
+
+describe('AuthController', () => {
+  let controller: AuthController
+  const service = { login: jest.fn() }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AuthController],
+      providers: [{ provide: AuthService, useValue: service }],
+    }).compile()
+
+    controller = module.get<AuthController>(AuthController)
+  })
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined()
+  })
+
+  it('delegates login', async () => {
+    await controller.login('test@example.com')
+    expect(service.login).toHaveBeenCalledWith('test@example.com')
+  })
+})

--- a/backend/src/projects/projects.controller.spec.ts
+++ b/backend/src/projects/projects.controller.spec.ts
@@ -1,0 +1,52 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { ProjectsController } from './projects.controller'
+import { ProjectsService } from './projects.service'
+
+describe('ProjectsController', () => {
+  let controller: ProjectsController
+  const service = {
+    create: jest.fn(),
+    findAll: jest.fn(),
+    findOne: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ProjectsController],
+      providers: [{ provide: ProjectsService, useValue: service }],
+    }).compile()
+
+    controller = module.get<ProjectsController>(ProjectsController)
+  })
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined()
+  })
+
+  it('delegates create', () => {
+    controller.create({ name: 'Test' } as any)
+    expect(service.create).toHaveBeenCalled()
+  })
+
+  it('delegates findAll', () => {
+    controller.findAll()
+    expect(service.findAll).toHaveBeenCalled()
+  })
+
+  it('delegates findOne', () => {
+    controller.findOne('1')
+    expect(service.findOne).toHaveBeenCalledWith('1')
+  })
+
+  it('delegates update', () => {
+    controller.update('1', { name: 'U' } as any)
+    expect(service.update).toHaveBeenCalledWith('1', { name: 'U' })
+  })
+
+  it('delegates remove', () => {
+    controller.remove('1')
+    expect(service.remove).toHaveBeenCalledWith('1')
+  })
+})

--- a/backend/src/tasks/tasks.controller.spec.ts
+++ b/backend/src/tasks/tasks.controller.spec.ts
@@ -1,0 +1,34 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { TasksController } from './tasks.controller'
+import { TasksService } from './tasks.service'
+
+describe('TasksController', () => {
+  let controller: TasksController
+  const service = {
+    findAll: jest.fn(),
+    toggle: jest.fn(),
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TasksController],
+      providers: [{ provide: TasksService, useValue: service }],
+    }).compile()
+
+    controller = module.get<TasksController>(TasksController)
+  })
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined()
+  })
+
+  it('gets tasks', () => {
+    controller.getTasks()
+    expect(service.findAll).toHaveBeenCalled()
+  })
+
+  it('toggles task', () => {
+    controller.toggleTask('1')
+    expect(service.toggle).toHaveBeenCalledWith(1)
+  })
+})

--- a/backend/src/users/users.controller.spec.ts
+++ b/backend/src/users/users.controller.spec.ts
@@ -1,0 +1,52 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { UsersController } from './users.controller'
+import { UsersService } from './users.service'
+
+describe('UsersController', () => {
+  let controller: UsersController
+  const service = {
+    create: jest.fn(),
+    findAll: jest.fn(),
+    findOne: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UsersController],
+      providers: [{ provide: UsersService, useValue: service }],
+    }).compile()
+
+    controller = module.get<UsersController>(UsersController)
+  })
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined()
+  })
+
+  it('delegates create', () => {
+    controller.create({} as any)
+    expect(service.create).toHaveBeenCalled()
+  })
+
+  it('delegates findAll', () => {
+    controller.findAll()
+    expect(service.findAll).toHaveBeenCalled()
+  })
+
+  it('delegates findOne', () => {
+    controller.findOne('1')
+    expect(service.findOne).toHaveBeenCalledWith('1')
+  })
+
+  it('delegates update', () => {
+    controller.update('1', {} as any)
+    expect(service.update).toHaveBeenCalledWith('1', {})
+  })
+
+  it('delegates remove', () => {
+    controller.remove('1')
+    expect(service.remove).toHaveBeenCalledWith('1')
+  })
+})


### PR DESCRIPTION
## Summary
- add basic AI service using fetch and registration via AiModule
- extend AppModule with AiModule
- add controller unit tests for auth, tasks, projects and users
- create tests for AiService
- mark tasks complete for backend tests and AI module
- document changes in CHANGELOG

## Testing
- `npm run lint`
- `flake8`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_b_68845a130fc88320acaed57355c7f97b