### PR TITLE
Implement Mem0 service and update AI module

### DIFF
--- a/.project-management/current-prd/tasks-feature-specification.md
+++ b/.project-management/current-prd/tasks-feature-specification.md
@@ -91,6 +91,8 @@
 - `backend/src/ai/ai.module.ts` - ChatGPT and Mem0 integration
 - `backend/src/ai/ai.service.ts` - AI interaction logic
 - `backend/src/ai/ai.service.spec.ts` - Tests for AI service
+- `backend/src/ai/mem0.service.ts` - Mem0 integration service
+- `backend/src/ai/mem0.service.spec.ts` - Tests for Mem0 service
 - `backend/src/tasks/tasks.controller.spec.ts` - Tests for tasks controller
 - `backend/src/projects/projects.controller.spec.ts` - Tests for projects controller
 - `backend/src/users/users.controller.spec.ts` - Tests for users controller
@@ -124,6 +126,9 @@
 - `backend/src/tasks/tasks.module.ts` - Inject notifications gateway
 - `backend/src/app.module.ts` - Register TasksModule, ProjectsModule, AuthModule, and AiModule
 - `backend/src/prisma/prisma.service.ts` - Run migrations at startup
+- `backend/src/ai/ai.module.ts` - Register Mem0Service
+- `backend/src/ai/ai.service.ts` - Use Mem0Service for context
+- `backend/src/ai/ai.service.spec.ts` - Updated tests for Mem0 integration
 - `README.md` - Update setup instructions
 - `.gitignore` - Ignore local environment files
 - `.project-management/current-prd/tasks-feature-specification.md` - Task list
@@ -147,7 +152,7 @@
   - [x] 2.5 Write unit tests for each service and controller
 - [ ] **3.0 AI Integration**
   - [x] 3.1 Create AI module to interface with ChatGPT API for task generation and summarization
-  - [ ] 3.2 Integrate Mem0 for semantic memory storage and retrieval-augmented responses
+  - [x] 3.2 Integrate Mem0 for semantic memory storage and retrieval-augmented responses
   - [ ] 3.3 Implement proactive suggestion logic leveraging interaction history
   - [x] 3.4 Add tests for AI services and stub external API calls
 - [x] **4.0 Frontend Implementation**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,4 @@
 2025-07-26T03:10:12Z Implement basic JWT auth module
 2025-07-26T03:33:38Z Add Graph service and controller unit tests
 2025-07-26T04:38:21Z Add AI module and controller tests
+2025-07-26T04:55:16Z Integrate Mem0 service and update AI module

--- a/backend/src/ai/ai.module.ts
+++ b/backend/src/ai/ai.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common'
 import { AiService } from './ai.service'
+import { Mem0Service } from './mem0.service'
 
 @Module({
-  providers: [AiService],
+  providers: [AiService, Mem0Service],
   exports: [AiService],
 })
 export class AiModule {}

--- a/backend/src/ai/ai.service.spec.ts
+++ b/backend/src/ai/ai.service.spec.ts
@@ -1,15 +1,21 @@
 import { AiService } from './ai.service'
+import { Mem0Service } from './mem0.service'
 
 describe('AiService', () => {
   let service: AiService
   let mockFetch: jest.Mock
+  let mem0: Mem0Service
 
   beforeEach(() => {
     mockFetch = jest.fn().mockResolvedValue({
       json: () => Promise.resolve({ choices: [{ message: { content: 'resp' } }] }),
     })
     global.fetch = mockFetch as any
-    service = new AiService()
+    mem0 = {
+      storeInteraction: jest.fn().mockResolvedValue(undefined),
+      search: jest.fn().mockResolvedValue([]),
+    } as any
+    service = new AiService(mem0)
   })
 
   it('generates tasks', async () => {
@@ -18,6 +24,8 @@ describe('AiService', () => {
     })
     const result = await service.generateTasks('todo')
     expect(result).toEqual(['a', 'b'])
+    expect(mem0.search).toHaveBeenCalledWith('todo')
+    expect(mem0.storeInteraction).toHaveBeenCalledWith('todo')
   })
 
   it('summarizes text', async () => {
@@ -26,5 +34,6 @@ describe('AiService', () => {
     })
     const result = await service.summarize('text')
     expect(result).toBe('sum')
+    expect(mem0.storeInteraction).toHaveBeenCalledWith('text')
   })
 })

--- a/backend/src/ai/ai.service.ts
+++ b/backend/src/ai/ai.service.ts
@@ -1,11 +1,14 @@
 import { Injectable } from '@nestjs/common'
+import { Mem0Service } from './mem0.service'
 
 @Injectable()
 export class AiService {
-  constructor() {}
+  constructor(private readonly mem0: Mem0Service) {}
 
   async generateTasks(prompt: string): Promise<string[]> {
-    const res = await this.request(prompt)
+    const context = await this.mem0.search(prompt)
+    const res = await this.request(`${context.join('\n')}\n${prompt}`)
+    await this.mem0.storeInteraction(prompt)
     const content = res || ''
     return content
       .split('\n')
@@ -14,6 +17,7 @@ export class AiService {
   }
 
   async summarize(text: string): Promise<string> {
+    await this.mem0.storeInteraction(text)
     return this.request(`Summarize the following text:\n${text}`)
   }
 

--- a/backend/src/ai/mem0.service.spec.ts
+++ b/backend/src/ai/mem0.service.spec.ts
@@ -1,0 +1,23 @@
+import { Mem0Service } from './mem0.service'
+
+describe('Mem0Service', () => {
+  let service: Mem0Service
+  let mockFetch: jest.Mock
+
+  beforeEach(() => {
+    mockFetch = jest.fn().mockResolvedValue({ json: () => Promise.resolve({ results: ['a'] }) })
+    global.fetch = mockFetch as any
+    service = new Mem0Service()
+  })
+
+  it('stores interaction', async () => {
+    mockFetch.mockResolvedValueOnce({ json: () => Promise.resolve({}) })
+    await service.storeInteraction('hello')
+    expect(mockFetch).toHaveBeenCalled()
+  })
+
+  it('searches memory', async () => {
+    const res = await service.search('query')
+    expect(res).toEqual(['a'])
+  })
+})

--- a/backend/src/ai/mem0.service.ts
+++ b/backend/src/ai/mem0.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common'
+
+@Injectable()
+export class Mem0Service {
+  async storeInteraction(text: string): Promise<void> {
+    await fetch(`${process.env.MEM0_URL}/store`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.MEM0_API_KEY}`,
+      },
+      body: JSON.stringify({ text }),
+    })
+  }
+
+  async search(query: string): Promise<string[]> {
+    const res = await fetch(`${process.env.MEM0_URL}/search`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.MEM0_API_KEY}`,
+      },
+      body: JSON.stringify({ query }),
+    })
+    const data = await res.json()
+    return data.results || []
+  }
+}


### PR DESCRIPTION
## Summary
- integrate Mem0 semantic memory service
- connect AiService to Mem0Service
- provide tests for new functionality
- update task list
- update changelog

## Testing
- `flake8`
- `npm run lint` in `frontend`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_b_68845ebe3368832095ab3de3ef5b1025