### PR TITLE
Implement AI suggestions feature

### DIFF
--- a/.project-management/current-prd/tasks-feature-specification.md
+++ b/.project-management/current-prd/tasks-feature-specification.md
@@ -150,10 +150,10 @@
   - [x] 2.3 Implement NestJS modules, controllers, and services for Users, Projects, Tasks, and Notifications
   - [x] 2.4 Add JWT authentication and OAuth2 (Google/Microsoft) using `auth` module
   - [x] 2.5 Write unit tests for each service and controller
-- [ ] **3.0 AI Integration**
+- [x] **3.0 AI Integration**
   - [x] 3.1 Create AI module to interface with ChatGPT API for task generation and summarization
   - [x] 3.2 Integrate Mem0 for semantic memory storage and retrieval-augmented responses
-  - [ ] 3.3 Implement proactive suggestion logic leveraging interaction history
+  - [x] 3.3 Implement proactive suggestion logic leveraging interaction history
   - [x] 3.4 Add tests for AI services and stub external API calls
 - [x] **4.0 Frontend Implementation**
   - [x] 4.1 Scaffold dashboard page and task list component with DaisyUI styling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@
 2025-07-26T03:33:38Z Add Graph service and controller unit tests
 2025-07-26T04:38:21Z Add AI module and controller tests
 2025-07-26T04:55:16Z Integrate Mem0 service and update AI module
+2025-07-26T05:00:37Z Add suggestion logic to AI service

--- a/backend/src/ai/ai.service.spec.ts
+++ b/backend/src/ai/ai.service.spec.ts
@@ -36,4 +36,14 @@ describe('AiService', () => {
     expect(result).toBe('sum')
     expect(mem0.storeInteraction).toHaveBeenCalledWith('text')
   })
+
+  it('suggests next tasks', async () => {
+    mockFetch.mockResolvedValueOnce({
+      json: () => Promise.resolve({ choices: [{ message: { content: 's1\ns2' } }] }),
+    })
+    const result = await service.getSuggestions('context')
+    expect(result).toEqual(['s1', 's2'])
+    expect(mem0.search).toHaveBeenCalledWith('context')
+    expect(mem0.storeInteraction).toHaveBeenCalledWith('context')
+  })
 })

--- a/backend/src/ai/ai.service.ts
+++ b/backend/src/ai/ai.service.ts
@@ -16,6 +16,17 @@ export class AiService {
       .filter(Boolean)
   }
 
+  async getSuggestions(context: string): Promise<string[]> {
+    const history = await this.mem0.search(context)
+    const prompt = `Based on the following interaction history:\n${history.join('\n')}\nSuggest next tasks for: ${context}`
+    const res = await this.request(prompt)
+    await this.mem0.storeInteraction(context)
+    return res
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean)
+  }
+
   async summarize(text: string): Promise<string> {
     await this.mem0.storeInteraction(text)
     return this.request(`Summarize the following text:\n${text}`)


### PR DESCRIPTION
## Summary
- enable proactive AI suggestions using interaction history
- test the new suggestion logic
- update task list to mark AI integration done
- document change in CHANGELOG

## Testing
- `flake8`
- `cd frontend && npm run lint`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_b_68846076154c8320a3648ad336645f48