### PR TITLE
Add Playwright scaffold

### DIFF
--- a/.project-management/current-prd/tasks-feature-specification.md
+++ b/.project-management/current-prd/tasks-feature-specification.md
@@ -106,6 +106,8 @@
 - `Dockerfile.frontend` - Frontend container
 - `.env.template` - Example environment variables
 - `frontend/src/components/TaskList.test.tsx` - Unit tests for `TaskList`
+- `frontend/playwright.config.ts` - Playwright configuration for E2E tests
+- `frontend/tests/home.e2e.ts` - Basic end-to-end test for homepage
 - `backend/src/tasks/tasks.service.spec.ts` - Tests for task service
 - `backend/src/integrations/graph/graph.service.spec.ts` - Tests for Microsoft Graph service
 - `backend/src/integrations/graph/graph.controller.spec.ts` - Tests for Microsoft Graph controller
@@ -132,6 +134,7 @@
 - `README.md` - Update setup instructions
 - `.gitignore` - Ignore local environment files
 - `.project-management/current-prd/tasks-feature-specification.md` - Task list
+- `run_tests.sh` - Test runner script with coverage and e2e support
 
 ### Notes
 - **Tech Stack**: Next.js 14+ with App Router, TypeScript, Tailwind CSS + DaisyUI, Zustand state management, React Query for API data, NestJS backend with Prisma ORM, y-websocket for collaboration.
@@ -169,7 +172,8 @@
 - [ ] **6.0 Testing & Quality Assurance**
   - [x] 6.1 Configure Jest and ESLint pre-commit hooks
   - [ ] 6.2 Achieve >80% unit test coverage across frontend and backend
-  - [ ] 6.3 Implement end-to-end tests using Playwright or Cypress
+  - [c] 6.3 Implement end-to-end tests using Playwright or Cypress
+    - [x] 6.3.1 Add initial Playwright configuration and sample home page test
 - [ ] **7.0 Deployment & Monitoring**
   - [ ] 7.1 Deploy containers to cloud environment (Kubernetes or DO App Platform)
   - [ ] 7.2 Set up OpenTelemetry traces, Prometheus metrics, Grafana dashboards, and Sentry error reporting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,4 @@
 2025-07-26T04:38:21Z Add AI module and controller tests
 2025-07-26T04:55:16Z Integrate Mem0 service and update AI module
 2025-07-26T05:00:37Z Add suggestion logic to AI service
+2025-07-26T07:36:20Z Add Playwright E2E test scaffolding

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "next": "^14.2.0",
@@ -34,6 +35,7 @@
     "eslint-config-next": "^14.2.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "@playwright/test": "^1.41.2",
     "postcss": "^8.4.31",
     "tailwindcss": "^3.4.4",
     "typescript": "^5.4.0"

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,16 @@
+import { PlaywrightTestConfig } from '@playwright/test'
+
+const config: PlaywrightTestConfig = {
+  webServer: {
+    command: 'npm run dev',
+    port: 3000,
+    timeout: 120 * 1000,
+    reuseExistingServer: true,
+  },
+  use: {
+    baseURL: 'http://localhost:3000',
+    headless: true,
+  },
+}
+
+export default config

--- a/frontend/tests/home.e2e.ts
+++ b/frontend/tests/home.e2e.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test'
+
+test('homepage shows heading', async ({ page }) => {
+  await page.goto('/')
+  await expect(page.getByRole('heading', { name: /hello there!/i })).toBeVisible()
+})

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -47,6 +47,15 @@ else
   echo "✅ Frontend tests completed"
 fi
 
+# End-to-end tests with Playwright
+if [ -f node_modules/.bin/playwright ]; then
+  echo "🎭 Running Playwright end-to-end tests..."
+  npx playwright install --with-deps >/dev/null 2>&1 || true
+  npm run test:e2e || echo "⚠️  Playwright tests failed"
+else
+  echo "Playwright not installed, skipping e2e tests"
+fi
+
 cd ..
 
 echo "🎉 All tests completed!"


### PR DESCRIPTION
## Summary
- add Playwright configuration and basic home page test
- skip Playwright in run_tests when not installed
- record this addition in CHANGELOG
- update tasks to track progress

## Testing
- `npm --prefix frontend run lint`
- `flake8`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_b_68848272e09c8320b5ed256578b6d27e