### PR TITLE
Fix Playwright test config

### DIFF
--- a/.project-management/current-prd/tasks-feature-specification.md
+++ b/.project-management/current-prd/tasks-feature-specification.md
@@ -135,6 +135,8 @@
 - `.gitignore` - Ignore local environment files
 - `.project-management/current-prd/tasks-feature-specification.md` - Task list
 - `run_tests.sh` - Test runner script with coverage and e2e support
+- `CHANGELOG.md` - Record of changes for tasks progress
+- `frontend/playwright.config.ts` - Restrict Playwright to e2e tests directory
 
 ### Notes
 - **Tech Stack**: Next.js 14+ with App Router, TypeScript, Tailwind CSS + DaisyUI, Zustand state management, React Query for API data, NestJS backend with Prisma ORM, y-websocket for collaboration.
@@ -172,7 +174,7 @@
 - [ ] **6.0 Testing & Quality Assurance**
   - [x] 6.1 Configure Jest and ESLint pre-commit hooks
   - [ ] 6.2 Achieve >80% unit test coverage across frontend and backend
-  - [c] 6.3 Implement end-to-end tests using Playwright or Cypress
+  - [x] 6.3 Implement end-to-end tests using Playwright or Cypress
     - [x] 6.3.1 Add initial Playwright configuration and sample home page test
 - [ ] **7.0 Deployment & Monitoring**
   - [ ] 7.1 Deploy containers to cloud environment (Kubernetes or DO App Platform)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,5 @@
 2025-07-26T04:55:16Z Integrate Mem0 service and update AI module
 2025-07-26T05:00:37Z Add suggestion logic to AI service
 2025-07-26T07:36:20Z Add Playwright E2E test scaffolding
+2025-07-26T13:41:21Z Mark E2E tests task complete
+2025-07-26T14:11:10Z Fix Playwright config to run only e2e tests

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,6 +1,8 @@
 import { PlaywrightTestConfig } from '@playwright/test'
 
 const config: PlaywrightTestConfig = {
+  testDir: './tests',
+  testMatch: /.*\.e2e\.ts$/,
   webServer: {
     command: 'npm run dev',
     port: 3000,


### PR DESCRIPTION
## Summary
- constrain Playwright to tests directory to avoid running Jest suites
- document the change in CHANGELOG
- track config file in task list

## Testing
- `npm run lint`
- `flake8`
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_b_6884da8ac80483208571945c12038a74