### PR TITLE
Implement coverage checks

### DIFF
--- a/.project-management/current-prd/tasks-feature-specification.md
+++ b/.project-management/current-prd/tasks-feature-specification.md
@@ -117,6 +117,7 @@
 - `backend/prisma/schema.prisma` - Add new tables according to PRD
 - `backend/package.json` - Add dependencies like @nestjs/jwt, @prisma/client
 - `frontend/package.json` - Add Zustand and React Query
+- `frontend/jest.config.js` - Enable coverage thresholds
  - `frontend/src/app/dashboard/page.tsx` - Display today's plan and all tasks
  - `frontend/src/components/TaskList.tsx` - Show due dates and status badges
  - `frontend/src/hooks/useApi.ts` - Add ApiTask dueDate property
@@ -173,7 +174,7 @@
   - [x] 5.4 Document Docker workflow in README and `dev_init.sh`
 - [ ] **6.0 Testing & Quality Assurance**
   - [x] 6.1 Configure Jest and ESLint pre-commit hooks
-  - [ ] 6.2 Achieve >80% unit test coverage across frontend and backend
+  - [c] 6.2 Achieve >80% unit test coverage across frontend and backend
   - [x] 6.3 Implement end-to-end tests using Playwright or Cypress
     - [x] 6.3.1 Add initial Playwright configuration and sample home page test
 - [ ] **7.0 Deployment & Monitoring**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,5 @@
 2025-07-26T07:36:20Z Add Playwright E2E test scaffolding
 2025-07-26T13:41:21Z Mark E2E tests task complete
 2025-07-26T14:11:10Z Fix Playwright config to run only e2e tests
+
+2025-07-26T16:00:27Z Add coverage thresholds and scripts for test coverage

--- a/backend/package.json
+++ b/backend/package.json
@@ -81,6 +81,14 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
+    "coverageThreshold": {
+      "global": {
+        "branches": 0.8,
+        "functions": 0.8,
+        "lines": 0.8,
+        "statements": 0.8
+      }
+    },
     "testEnvironment": "node"
   }
 }

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -10,6 +10,16 @@ const customJestConfig = {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
+  collectCoverageFrom: ['<rootDir>/src/**/*.{ts,tsx}'],
+  coverageDirectory: '<rootDir>/coverage',
+  coverageThreshold: {
+    global: {
+      branches: 0.8,
+      functions: 0.8,
+      lines: 0.8,
+      statements: 0.8,
+    },
+  },
 }
 
 module.exports = createJestConfig(customJestConfig)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint",
     "test": "jest",
     "test:watch": "jest --watch",
+    "test:cov": "jest --coverage",
     "test:e2e": "playwright test"
   },
   "dependencies": {

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -22,8 +22,8 @@ fi
 if ! npx jest --version >/dev/null 2>&1; then
   echo "Jest not installed, skipping backend tests"
 else
-  echo "Running Jest tests for NestJS backend..."
-  npm run test
+  echo "Running Jest tests for NestJS backend with coverage..."
+  npm run test:cov
   echo "✅ Backend tests completed"
 fi
 
@@ -42,8 +42,8 @@ fi
 if ! npx jest --version >/dev/null 2>&1; then
   echo "Jest not installed, skipping frontend tests"
 else
-  echo "Running Jest tests for Next.js frontend..."
-  npm run test
+  echo "Running Jest tests for Next.js frontend with coverage..."
+  npm run test:cov
   echo "✅ Frontend tests completed"
 fi
 


### PR DESCRIPTION
## Summary
- commit to improving test coverage in task list
- enforce coverage in `run_tests.sh`
- add coverage thresholds to backend and frontend configs
- expose coverage script via frontend package.json
- log changes in CHANGELOG

## Testing
- `npm run lint` in frontend
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_b_6884fa03d1088320a478ce8f50089689